### PR TITLE
fix(e2e): add auth fixture to prevent login redirect in CI

### DIFF
--- a/frontend/tests/e2e/absence-entry.spec.ts
+++ b/frontend/tests/e2e/absence-entry.spec.ts
@@ -12,7 +12,7 @@
  * - Calendar shows absence hours with appropriate styling (blue background, 🏖️ icon)
  */
 
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures/auth";
 
 test.describe("Absence Entry Workflow", () => {
   const memberId = "00000000-0000-0000-0000-000000000001";

--- a/frontend/tests/e2e/accessibility.spec.ts
+++ b/frontend/tests/e2e/accessibility.spec.ts
@@ -12,7 +12,7 @@
  */
 
 import AxeBuilder from "@axe-core/playwright";
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures/auth";
 
 test.describe("Accessibility - WCAG 2.1 AA Compliance", () => {
   const memberId = "00000000-0000-0000-0000-000000000001";

--- a/frontend/tests/e2e/approval-workflow.spec.ts
+++ b/frontend/tests/e2e/approval-workflow.spec.ts
@@ -13,7 +13,7 @@
  * - Resubmit and approve workflow works correctly
  */
 
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures/auth";
 
 test.describe("Approval Workflow", () => {
   const memberId = "00000000-0000-0000-0000-000000000001";

--- a/frontend/tests/e2e/auto-save.spec.ts
+++ b/frontend/tests/e2e/auto-save.spec.ts
@@ -12,7 +12,7 @@
  * - Auto-save doesn't trigger for read-only entries
  */
 
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures/auth";
 
 test.describe("Auto-Save Reliability", () => {
   const memberId = "00000000-0000-0000-0000-000000000001";

--- a/frontend/tests/e2e/copy-previous-month.spec.ts
+++ b/frontend/tests/e2e/copy-previous-month.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures/auth";
 
 /**
  * E2E tests for Copy Previous Month feature.

--- a/frontend/tests/e2e/csv-operations.spec.ts
+++ b/frontend/tests/e2e/csv-operations.spec.ts
@@ -1,4 +1,4 @@
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures/auth";
 
 /**
  * E2E tests for CSV Import/Export operations.

--- a/frontend/tests/e2e/daily-entry.spec.ts
+++ b/frontend/tests/e2e/daily-entry.spec.ts
@@ -11,7 +11,7 @@
  * - Data persists after page reload
  */
 
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures/auth";
 
 test.describe("Daily Entry Workflow", () => {
   const memberId = "00000000-0000-0000-0000-000000000001";

--- a/frontend/tests/e2e/fixtures/auth.ts
+++ b/frontend/tests/e2e/fixtures/auth.ts
@@ -1,0 +1,18 @@
+import { test as base } from "@playwright/test";
+
+const TEST_USER = {
+  id: "00000000-0000-0000-0000-000000000001",
+  email: "bob@example.com",
+  displayName: "Test Engineer",
+};
+
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await page.addInitScript((user) => {
+      window.sessionStorage.setItem("miometry_auth_user", JSON.stringify(user));
+    }, TEST_USER);
+    await use(page);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/frontend/tests/e2e/multi-project-entry.spec.ts
+++ b/frontend/tests/e2e/multi-project-entry.spec.ts
@@ -6,7 +6,7 @@
  * and verify the 24-hour daily limit validation.
  */
 
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures/auth";
 
 test.describe("Multi-project time allocation", () => {
   const projectA = "11111111-1111-1111-1111-111111111111";

--- a/frontend/tests/e2e/proxy-entry.spec.ts
+++ b/frontend/tests/e2e/proxy-entry.spec.ts
@@ -13,7 +13,7 @@
  * - Manager can exit proxy mode and return to their own timesheet
  */
 
-import { expect, test } from "@playwright/test";
+import { expect, test } from "./fixtures/auth";
 
 test.describe("Proxy Entry Workflow", () => {
   const managerId = "00000000-0000-0000-0000-000000000001";


### PR DESCRIPTION
## Summary
- E2E テストが CI で全 146 テスト失敗していた原因を修正
- `AuthGuard` が `sessionStorage` の認証データ未設定で `/login` にリダイレクトしていた
- Playwright の `addInitScript()` で認証データを注入する共通フィクスチャ (`fixtures/auth.ts`) を作成
- `/worklog` 系テスト 9 ファイルの import を新フィクスチャに変更
- `/password-reset` 系テスト（認証不要ルート）は変更なし

## Test Plan
- [ ] CI の E2E テストジョブが全テスト通過すること
- [ ] テストが `/worklog` を正しく表示し、`/login` にリダイレクトされないこと
- [ ] `password-reset-accessibility` テストが引き続き正常動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)