### PR TITLE
fix: ToastProvider の context value を useMemo で安定化し無限ループを修正

### DIFF
--- a/frontend/app/components/admin/TenantSettingsSection.tsx
+++ b/frontend/app/components/admin/TenantSettingsSection.tsx
@@ -26,6 +26,7 @@ export function TenantSettingsSection() {
   const [showFyForm, setShowFyForm] = useState(false);
   const [showMpForm, setShowMpForm] = useState(false);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: toast.error is stable via useMemo but excluded defensively (see #131)
   useEffect(() => {
     if (!tenantId) return;
     let cancelled = false;
@@ -59,7 +60,7 @@ export function TenantSettingsSection() {
     return () => {
       cancelled = true;
     };
-  }, [tenantId, toast, t]);
+  }, [tenantId, t]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: t from useTranslations is stable
   const handleSave = useCallback(async () => {

--- a/frontend/app/components/shared/ToastProvider.tsx
+++ b/frontend/app/components/shared/ToastProvider.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { createContext, type ReactNode, useCallback, useEffect, useRef, useState } from "react";
+import { createContext, type ReactNode, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ToastItem, ToastVariant } from "@/hooks/useToast";
 import { Toast } from "./Toast";
 
@@ -59,12 +59,12 @@ export function ToastProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  const value: ToastContextValue = {
-    success: useCallback((msg: string) => addToast(msg, "success"), [addToast]),
-    error: useCallback((msg: string) => addToast(msg, "error"), [addToast]),
-    warning: useCallback((msg: string) => addToast(msg, "warning"), [addToast]),
-    info: useCallback((msg: string) => addToast(msg, "info"), [addToast]),
-  };
+  const success = useCallback((msg: string) => addToast(msg, "success"), [addToast]);
+  const error = useCallback((msg: string) => addToast(msg, "error"), [addToast]);
+  const warning = useCallback((msg: string) => addToast(msg, "warning"), [addToast]);
+  const info = useCallback((msg: string) => addToast(msg, "info"), [addToast]);
+
+  const value: ToastContextValue = useMemo(() => ({ success, error, warning, info }), [success, error, warning, info]);
 
   return (
     <ToastContext.Provider value={value}>


### PR DESCRIPTION
## 概要
- テナント管理者が `/admin/settings` を開いた際、API エラー時に無限ループが発生するバグを修正
- ToastProvider の context value が毎レンダーで新規生成されていたことが根本原因

## 主な変更
- **ToastProvider.tsx**: `useCallback` で生成した各メソッドを変数に分離し、`value` オブジェクトを `useMemo` で包むことで参照を安定化
- **TenantSettingsSection.tsx**: `useEffect` の依存配列から `toast` を防御的に除外（`useMemo` 適用後は安定するが、再発防止のため）

## 検証チェックリスト
- [ ] テナント管理者（David）で `/admin/settings` を開き、API エラー時に無限ループが発生しないことを確認
- [ ] Toast 通知（success/error/warning/info）が正常に表示されることを確認
- [ ] TenantSettingsSection のデータ読み込み・保存が正常に動作することを確認
- [ ] 他のコンポーネントでの toast 使用箇所に影響がないことを確認

Closes #131

🤖 Generated with [Claude Code](https://claude.com/claude-code)